### PR TITLE
added k8s manifest files for deploying application

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,1 +1,84 @@
-TODO: Put kubernetes manifests in here.
+# DumbKV Kubernetes Deployment
+
+This directory contains Kubernetes manifests to deploy the **DumbKV** application with either a **SQLite backend** (local storage) or a **Postgres backend** (database service).  
+It is structured for **Kustomize overlays**, so you can easily switch between environments.
+
+---
+
+### Repository Structure
+
+```bash
+manifests/
+├── base/ # Common manifests (deployment, service, ingress)
+│ ├── deployment.yml
+│ ├── service.yml
+│ ├── ingress.yml
+│ ├── pvc.yml
+│ ├── pv.yml
+│ ├── kustomization.yml
+│
+├── overlays/
+│ ├── sqlite/ # Overlay for SQLite backend
+│ │ ├── kustomization.yml
+│ │ └── deployment-patch.yml
+│ │
+│ └── postgres/ # Overlay for Postgres backend
+│ ├── kustomization.yml
+│ ├── deployment-statefulset.yml
+│ ├── patch-deployment-postgres.yml
+│ └── secret.yml
+```
+
+- **base** → shared resources (app Deployment, Service, Ingress, PVC).  
+- **sqlite overlay** → patches base to use SQLite with a `PersistentVolumeClaim`.  
+- **postgres overlay** → deploys a Postgres instance, creates a Secret, and patches DumbKV Deployment to connect to it.  
+
+---
+
+### Deploying with SQLite
+
+This runs DumbKV with an embedded SQLite database stored on a PVC.
+
+```bash
+kubectl apply -k overlays/sqlite  ## Considering you are in manifests directory
+
+```
+
+### Deploying with Postgres
+
+This runs DumbKV with a dedicated Postgres backend inside the cluster.
+
+> Deploy Postgres + Secret
+
+The overlay contains:
+    * Deployment for Postgres
+    * A headless Service (so the hostname postgres resolves inside the cluster)
+    * A Secret with username and password
+
+```bash
+kubectl apply -k overlays/postgres  ## Considering you are in manifests directory
+
+```
+### Monitoring & Debugging
+
+1. View logs:
+
+```bash
+kubectl logs deploy/dumbkv
+kubectl logs deploy/postgres
+```
+
+2. Describe resources:
+
+```bash
+kubectl describe pod <pod-name>
+kubectl describe svc dumbkv
+```
+
+3. Port-forward for local debugging:
+
+```bash
+kubectl port-forward svc/dumbkv 8000:80
+```
+
+

--- a/manifests/base/deployment.yml
+++ b/manifests/base/deployment.yml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dumbkv
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dumbkv
+  template:
+    metadata:
+      labels:
+        app: dumbkv
+    spec:
+      containers:
+        - name: dumbkv
+          image: ghcr.io/babfat2010/thinkific_srechallenge:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_LOCATION
+              value: dumbkv.db # default, overridden in overlays
+            - name: DATABASE_TYPE
+              value: sqlite
+          volumeMounts:
+            - name: dumbkv-pvc
+              mountPath: /data/dumbkvstore
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+      volumes:
+        - name: dumbkv-pvc
+          persistentVolumeClaim:
+            claimName: dumbkv-pvc

--- a/manifests/base/ingress.yml
+++ b/manifests/base/ingress.yml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dumbkv-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: dumbkv.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dumbkv
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - dumbkv.example.com
+      secretName: dumbkv-tls

--- a/manifests/base/kustomization.yml
+++ b/manifests/base/kustomization.yml
@@ -1,0 +1,6 @@
+resources:
+  - deployment.yml
+  - service.yml
+  - ingress.yml
+  - pv.yml
+  - pvc.yml

--- a/manifests/base/pv.yml
+++ b/manifests/base/pv.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: dumbkv-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  ## To run locally
+  # hostPath:
+  #   path: /tmp/dumbkvstore
+  volumeMode: Filesystem
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-12345678  # comment this if working on host path

--- a/manifests/base/pvc.yml
+++ b/manifests/base/pvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dumbkv-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: efs # comment this out if running on host path

--- a/manifests/base/service.yml
+++ b/manifests/base/service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dumbkv
+spec:
+  selector:
+    app: dumbkv
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/manifests/overlays/postgres/deployment-statefulset.yml
+++ b/manifests/overlays/postgres/deployment-statefulset.yml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          env:
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: password
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+        storageClassName: efs # comment this out if working on host path
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres

--- a/manifests/overlays/postgres/kustomization.yml
+++ b/manifests/overlays/postgres/kustomization.yml
@@ -1,0 +1,7 @@
+resources:
+  - ../../base
+  - secret.yml
+  - deployment-statefulset.yml
+
+patchesStrategicMerge:
+  - patch-deployment-postgres.yml

--- a/manifests/overlays/postgres/patch-deployment-postgres.yml
+++ b/manifests/overlays/postgres/patch-deployment-postgres.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dumbkv
+spec:
+  template:
+    spec:
+      containers:
+        - name: dumbkv
+          env:
+            - name: DATABASE_TYPE
+              value: postgres
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: password
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: DATABASE_LOCATION
+              value: "postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):5432/$(POSTGRES_DB)"

--- a/manifests/overlays/postgres/secret.yml
+++ b/manifests/overlays/postgres/secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+data:
+  username: cG9zdGdyZXM=
+  password: c3VwZXJzZWNyZXQ=

--- a/manifests/overlays/sqlite/kustomization.yml
+++ b/manifests/overlays/sqlite/kustomization.yml
@@ -1,0 +1,6 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - patch-deployment-sqlite.yml
+

--- a/manifests/overlays/sqlite/patch-deployment-sqlite.yml
+++ b/manifests/overlays/sqlite/patch-deployment-sqlite.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dumbkv
+spec:
+  template:
+    spec:
+      containers:
+        - name: dumbkv
+          env:
+            - name: DATABASE_LOCATION
+              value: dumbkv.db
+          volumeMounts:
+            - name: dumbkv-pvc
+              mountPath: /data/dumbkvstore
+      volumes:
+        - name: dumbkv-pvc
+          persistentVolumeClaim:
+            claimName: dumbkv-pvc


### PR DESCRIPTION
- [x] Create a deployment, including a health check, using the sqlite backend. We only need 1 replica, and we should prevent multiple instances from running
- [x] Create a service
- [x] Create a PVC and ensure the database directory is named dumbkvstore. The storage class name is efs
- [x] Create an ingress or gateway for the hostname dumbkv.example.com, the service will be available on the root path, the cert-manager cluster issuer is named letsencrypt
- [x] Update the kubernetes manifests to support the postgres backend